### PR TITLE
[breaking] Make Republished vars binding

### DIFF
--- a/Tests/RepublishedTests/RepublishedTests.swift
+++ b/Tests/RepublishedTests/RepublishedTests.swift
@@ -1,5 +1,63 @@
+import Combine
+import SwiftUI
 import XCTest
 @testable import Republished
 
 final class RepublishedTests: XCTestCase {
+
+    @ObservedObject var outerObject = OuterObject()
+    var object: RepublishedObject!
+    var willChangeCount: Int!
+    var cancellable: AnyCancellable!
+
+    @MainActor
+    override func setUpWithError() throws {
+        willChangeCount = 0
+        outerObject = OuterObject()
+        object = outerObject.object
+        cancellable = outerObject.objectWillChange
+            .sink {
+                self.willChangeCount += 1
+            }
+    }
+
+    @MainActor
+    override func tearDownWithError() throws {
+        willChangeCount = nil
+        object = nil
+        cancellable = nil
+    }
+
+    func test_isRepublishedOnChange() {
+        XCTAssertEqual(willChangeCount, 0)
+        object.x = 100
+        XCTAssertEqual(willChangeCount, 1)
+    }
+
+    func test_isRepublishedOnChange_whenPrivateSet() {
+        XCTAssertEqual(willChangeCount, 0)
+        object.setY("goodbye")
+        XCTAssertEqual(willChangeCount, 1)
+    }
+
+    func test_isRepublishedOnChange_whenModifiedWithBinding() {
+        XCTAssertEqual(willChangeCount, 0)
+        let x = outerObject.$object.x
+        x.wrappedValue = 20
+        XCTAssertEqual(willChangeCount, 1)
+    }
+
+}
+
+final class OuterObject: ObservableObject {
+    @Republished var object = RepublishedObject()
+}
+
+final class RepublishedObject: ObservableObject {
+    @Published var x = 10
+    @Published private(set) var y = "Hello"
+
+    func setY(_ value: String) {
+        y = value
+    }
 }


### PR DESCRIPTION
1. make the projected value of a @Republished var be Binding
2. this breaks existing behavior—which was to use that accessor to expose internals.
3. the new way is better
4. also add tests.