### PR TITLE
Fix Retain Cycle

### DIFF
--- a/Sources/Republished/Republished.swift
+++ b/Sources/Republished/Republished.swift
@@ -80,8 +80,8 @@ public final class Republished<Wrapped> {
         // Proxies publish first on subscribe, but that happens in a read — which is during a view
         // update.
         .dropFirst()
-        .handleEvents(receiveCompletion: { _ in
-            storage.cancellable = nil
+        .handleEvents(receiveCompletion: { [weak storage] _ in
+            storage?.cancellable = nil
         })
         .sink { [objectWillChange = instance.objectWillChange] in
           objectWillChange.send()


### PR DESCRIPTION
The nested ObservableObject instances were not being deallocated correctly due to being retained when creating the subscription.